### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,12 +314,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
This fixes https://nvd.nist.gov/vuln/detail/CVE-2021-44832

